### PR TITLE
Adjust the build  to play nicer in IDEA.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -378,11 +378,18 @@
                     <artifactId>maven-bundle-plugin</artifactId>
                     <version>${version-maven-bundle-plugin}</version>
                     <extensions>true</extensions>
+                    <configuration>
+                        <manifestLocation>${project.build.directory}/generated-sources/bundle/META-INF</manifestLocation>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-scr-plugin</artifactId>
                     <version>${version-apache-felix-scr-plugin}</version>
+                    <configuration>
+                        <generateAccessors>false</generateAccessors>
+                        <outputDirectory>${project.build.directory}/generated-sources/scr</outputDirectory>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Adjust the maven-bundle-plugin and maven-scr-plugin to generate resources to a different directory from target/classes so that it plays nicer with IDEA projects.  IDEA tends to wipe the target/classes on not re-run plugins to re-generate the associated resources on a rebuild.
