### PR TITLE
#8 #7: Handle cyclic references in SubstitutionPropertiesProvider. Make ...

### DIFF
--- a/runtime/api/pom.xml
+++ b/runtime/api/pom.xml
@@ -68,6 +68,21 @@
 					</instructions>
 				</configuration>
 			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <environmentVariables>
+                        <GRAVIA_ENV1>gravia.value1</GRAVIA_ENV1>
+                        <GRAVIA_ENV2>gravia.value2</GRAVIA_ENV2>
+                        <CUSTOM_ENV1>custom.value1</CUSTOM_ENV1>
+                        <CUSTOM_ENV2>custom.value2</CUSTOM_ENV2>
+                    </environmentVariables>
+                    <systemProperties>
+                        <env1>system.value1</env1>
+                    </systemProperties>
+                </configuration>
+            </plugin>
 		</plugins>
 	</build>
 </project>

--- a/runtime/api/src/main/java/org/jboss/gravia/runtime/spi/CompositePropertiesProvider.java
+++ b/runtime/api/src/main/java/org/jboss/gravia/runtime/spi/CompositePropertiesProvider.java
@@ -41,4 +41,8 @@ public class CompositePropertiesProvider extends AbstractPropertiesProvider {
 		}
 		return defaultValue;
 	}
+
+    PropertiesProvider[] getDelegates() {
+        return delegates;
+    }
 }

--- a/runtime/api/src/main/java/org/jboss/gravia/runtime/spi/DefaultPropertiesProvider.java
+++ b/runtime/api/src/main/java/org/jboss/gravia/runtime/spi/DefaultPropertiesProvider.java
@@ -75,11 +75,14 @@ public class DefaultPropertiesProvider extends CompositePropertiesProvider {
     public DefaultPropertiesProvider(Map<String, Object> properties, final boolean systemPropertyDelegation, final String environmentVariablePrefix) {
         IllegalArgumentAssertion.assertNotNull(properties, "props");
         properties.putAll(propsToMap(getDefaultProperties()));
-        this.delegate = new SubstitutionPropertiesProvider(
+        PropertiesProvider system = systemPropertyDelegation ? new SystemPropertiesProvider() : new MapPropertiesProvider();
+        PropertiesProvider env =  environmentVariablePrefix != null ? new EnvPropertiesProvider(environmentVariablePrefix) : new EnvPropertiesProvider(system);
+
+                this.delegate = new SubstitutionPropertiesProvider(
                 new CompositePropertiesProvider(
                         new MapPropertiesProvider(properties),
-                        systemPropertyDelegation ? new SystemPropertiesProvider() : new MapPropertiesProvider(),
-                        new EnvPropertiesProvider(environmentVariablePrefix)
+                        system,
+                        env
                 )
         );
     }

--- a/runtime/api/src/main/java/org/jboss/gravia/runtime/spi/EnvPropertiesProvider.java
+++ b/runtime/api/src/main/java/org/jboss/gravia/runtime/spi/EnvPropertiesProvider.java
@@ -20,11 +20,14 @@
 package org.jboss.gravia.runtime.spi;
 
 
+import org.jboss.gravia.utils.IllegalArgumentAssertion;
+
 /**
  * A {@link org.jboss.gravia.runtime.spi.PropertiesProvider} backed by Environmental Variables.
  */
 public class EnvPropertiesProvider extends AbstractPropertiesProvider {
 
+    public static final String ENV_PREFIX_KEY = "environment.prefix";
     public static final String DEFAULT_ENV_PREFIX = "GRAVIA_";
     private static final String ENV_REPLACE_PATTERN = "-|\\.";
 
@@ -34,8 +37,18 @@ public class EnvPropertiesProvider extends AbstractPropertiesProvider {
         this(DEFAULT_ENV_PREFIX);
     }
 
+    public EnvPropertiesProvider(PropertiesProvider source) {
+        this(String.valueOf(source.getProperty(ENV_PREFIX_KEY)));
+    }
+
     public EnvPropertiesProvider(String environmentVariablePrefix) {
-        this.environmentVariablePrefix = environmentVariablePrefix != null ? environmentVariablePrefix : DEFAULT_ENV_PREFIX;
+        IllegalArgumentAssertion.assertNotNull(environmentVariablePrefix, "Environmental variable prefix");
+        this.environmentVariablePrefix = environmentVariablePrefix;
+    }
+
+    @Override
+    public Object getProperty(String key) {
+        return getProperty(key, null);
     }
 
     @Override

--- a/runtime/api/src/test/java/org/jboss/gravia/runtime/spi/SubstitutionPropertiesProviderTest.java
+++ b/runtime/api/src/test/java/org/jboss/gravia/runtime/spi/SubstitutionPropertiesProviderTest.java
@@ -1,17 +1,20 @@
 package org.jboss.gravia.runtime.spi;
 
 
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
+
 public class SubstitutionPropertiesProviderTest {
 
-    @Test
-    public void testGetProperty() throws Exception {
+    Map<String, Object> config = new HashMap<>();
 
-        Map<String, Object> config = new HashMap<>();
+    @Before
+    public void setUp() {
         config.put("key1", "value1");
         config.put("key2", "value2");
         config.put("key3", "${key2}");
@@ -20,16 +23,72 @@ public class SubstitutionPropertiesProviderTest {
         config.put("key6", "${key1}-${key3}");
         config.put("key7", "${key1}-${key8}");
 
+        //Let's add a cycle
+        config.put("env1", "${env1}");
+        config.put("env2", "${env2}");
+
+    }
+
+    @Test
+    public void testGetProperty() throws Exception {
         SubstitutionPropertiesProvider provider = new SubstitutionPropertiesProvider(new MapPropertiesProvider(config));
-
-
-        org.junit.Assert.assertEquals(null, provider.getProperty(""));
-        org.junit.Assert.assertEquals("value1", provider.getProperty("key1"));
-        org.junit.Assert.assertEquals("value2", provider.getProperty("key3"));
+        Assert.assertEquals(null, provider.getProperty(""));
+        Assert.assertEquals("value1", provider.getProperty("key1"));
+        Assert.assertEquals("value2", provider.getProperty("key3"));
         //Nested Substitution
-        org.junit.Assert.assertEquals("value1-value2", provider.getProperty("key6"));
-        org.junit.Assert.assertEquals("value1-", provider.getProperty("key7"));
+        Assert.assertEquals("value1-value2", provider.getProperty("key6"));
+        Assert.assertEquals("value1-", provider.getProperty("key7"));
         //Test infinite loop prevention
-        org.junit.Assert.assertEquals("", provider.getProperty("key5"));
+        Assert.assertEquals(null, provider.getProperty("key5"));
+        Assert.assertEquals(null, provider.getProperty("env1"));
+        Assert.assertEquals(null, provider.getProperty("env2"));
+
+    }
+
+    @Test
+    public void testWithSystemProperties() throws Exception {
+        SubstitutionPropertiesProvider provider = new SubstitutionPropertiesProvider(new MapPropertiesProvider(config), new SystemPropertiesProvider());
+        Assert.assertEquals(null, provider.getProperty(""));
+        Assert.assertEquals("value1", provider.getProperty("key1"));
+        Assert.assertEquals("value2", provider.getProperty("key3"));
+        //Nested Substitution
+        Assert.assertEquals("value1-value2", provider.getProperty("key6"));
+        Assert.assertEquals("value1-", provider.getProperty("key7"));
+        //Test infinite loop prevention
+        Assert.assertEquals(null, provider.getProperty("key5"));
+        Assert.assertEquals("system.value1", provider.getProperty("env1"));
+        Assert.assertEquals(null, provider.getProperty("env2"));
+    }
+
+    @Test
+    public void testWithSystemAndEnvProperties() throws Exception {
+        SubstitutionPropertiesProvider provider = new SubstitutionPropertiesProvider(new MapPropertiesProvider(config), new SystemPropertiesProvider(), new EnvPropertiesProvider());
+        Assert.assertEquals(null, provider.getProperty(""));
+        Assert.assertEquals("value1", provider.getProperty("key1"));
+        Assert.assertEquals("value2", provider.getProperty("key3"));
+        //Nested Substitution
+        Assert.assertEquals("value1-value2", provider.getProperty("key6"));
+        Assert.assertEquals("value1-", provider.getProperty("key7"));
+        //Test infinite loop prevention
+        Assert.assertEquals(null, provider.getProperty("key5"));
+        Assert.assertEquals("system.value1", provider.getProperty("env1"));
+        Assert.assertEquals("gravia.value2", provider.getProperty("env2"));
+    }
+
+    @Test
+    public void testWithSystemAndEnvWithCustomPrefixProperties() throws Exception {
+        Map<String, Object> envConf = new HashMap<>();
+        envConf.put(EnvPropertiesProvider.ENV_PREFIX_KEY, "CUSTOM_");
+        SubstitutionPropertiesProvider provider = new SubstitutionPropertiesProvider(new MapPropertiesProvider(config), new SystemPropertiesProvider(), new EnvPropertiesProvider(new MapPropertiesProvider(envConf)));
+        Assert.assertEquals(null, provider.getProperty(""));
+        Assert.assertEquals("value1", provider.getProperty("key1"));
+        Assert.assertEquals("value2", provider.getProperty("key3"));
+        //Nested Substitution
+        Assert.assertEquals("value1-value2", provider.getProperty("key6"));
+        Assert.assertEquals("value1-", provider.getProperty("key7"));
+        //Test infinite loop prevention
+        Assert.assertEquals(null, provider.getProperty("key5"));
+        Assert.assertEquals("system.value1", provider.getProperty("env1"));
+        Assert.assertEquals("custom.value2", provider.getProperty("env2"));
     }
 }

--- a/runtime/osgi/src/main/java/org/jboss/gravia/runtime/osgi/spi/OSGiPropertiesProvider.java
+++ b/runtime/osgi/src/main/java/org/jboss/gravia/runtime/osgi/spi/OSGiPropertiesProvider.java
@@ -22,8 +22,10 @@ package org.jboss.gravia.runtime.osgi.spi;
 import org.jboss.gravia.runtime.spi.AbstractPropertiesProvider;
 import org.jboss.gravia.runtime.spi.CompositePropertiesProvider;
 import org.jboss.gravia.runtime.spi.EnvPropertiesProvider;
+import org.jboss.gravia.runtime.spi.MapPropertiesProvider;
 import org.jboss.gravia.runtime.spi.PropertiesProvider;
 import org.jboss.gravia.runtime.spi.SubstitutionPropertiesProvider;
+import org.jboss.gravia.runtime.spi.SystemPropertiesProvider;
 import org.osgi.framework.BundleContext;
 
 /**
@@ -38,10 +40,16 @@ public class OSGiPropertiesProvider extends AbstractPropertiesProvider {
     }
 
     public OSGiPropertiesProvider(BundleContext bundleContext, String environmentVariablePrefix) {
-        this.delegate = new SubstitutionPropertiesProvider(new CompositePropertiesProvider(
-                new BundleContextPropertiesProvider(bundleContext),
-                new EnvPropertiesProvider(environmentVariablePrefix)
-        ));
+        PropertiesProvider system = new SystemPropertiesProvider();
+        PropertiesProvider env =  environmentVariablePrefix != null ? new EnvPropertiesProvider(environmentVariablePrefix) : new EnvPropertiesProvider(system);
+
+        this.delegate = new SubstitutionPropertiesProvider(
+                new CompositePropertiesProvider(
+                        new BundleContextPropertiesProvider(bundleContext),
+                        system,
+                        env
+                )
+        );
     }
 
     @Override


### PR DESCRIPTION
...EnvPropertiesProvider more flexible by allowing it to read the ENV_PREFIX from a PropertiesProvider (and use SystemPropertiesProvider as the default).
